### PR TITLE
Add .goog domains

### DIFF
--- a/data/google
+++ b/data/google
@@ -195,8 +195,9 @@ google.co.zm
 google.co.zw
 google.cat
 
-# All .google domains
+# All .google and .goog domains
 google
+goog
 
 # Others
 admob.com


### PR DESCRIPTION
Add .goog domains.
It is now used at Google Voice website.
(And sorry that I made a mistake just now.)
