### PR TITLE
Add yahoo.co.jp

### DIFF
--- a/data/yahoo
+++ b/data/yahoo
@@ -137,5 +137,6 @@ yahoo.com.vn
 yahoo.ws
 yahoo.co.za
 yahoo.cat
+yahoo.co.jp
 
 yimg.com


### PR DESCRIPTION
虽然 https://www.yahoo.co.jp/ 可以直接访问，但一些二级域名（如 https://search.yahoo.co.jp/ ）仍需代理。