### PR TITLE
Create XiaomiTV-ads

### DIFF
--- a/data/xiaomitv-ads
+++ b/data/xiaomitv-ads
@@ -1,0 +1,14 @@
+pandora.mi.com @ads
+ad.mi.com @ads
+ad.xiaomi.com @ads
+ad1.xiaomi.com @ads
+data.mistat.xiaomi.com @ads
+tracking.miui.com @ads
+adv.sec.miui.com @ads
+misc.in.duokanbox.com @ads
+ad.hpplay.cn @ads
+adeng.hpplay.cn @ads
+auth.api.gitv.tv @ads
+atianqi.com @ads
+kuyun.com @ads
+umeng.com @ads


### PR DESCRIPTION
这个规则需要将 V2Ray 安装在路由器上，如果不能请看最后一段。

主要屏蔽了一些影响使用的广告：开关机、弹窗、乐播投屏前 15 秒等，界面中不影响观看流程的广告则没有屏蔽。
使用此规则，可以正常使用 TV 内置的源播放，也可正常使用腾讯视频、爱奇艺进行投屏（即乐播投屏）。

> 设置后，请进入电视管家-深度清理-应用数据清理-adcare，再重启电视即可生效。

如果你的路由器不支持安装 V2Ray，则可以将网址复制并修改为对应的格式，粘贴于路由器的网址拦截功能中。如果是使用 hosts 功能，此列表可能无法满足，需要更丰富的二级、三级域名列表。