### PR TITLE
geolocation-cn: remove v2ex.com

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -382,7 +382,6 @@ u17.com
 useso.com
 upyun.com
 upaiyun.com
-v2ex.com
 v5875.com
 vamaker.com
 vancl.com


### PR DESCRIPTION
From [20190706 - 关于最近基础架构方面的一些变动](https://www.v2ex.com/t/580480)

`v2ex.com` transfered server to US, and using Cloudflare CDN.
So, remove from `geolocation-cn`.

---

`v2ex.com` 将服务器转移到了美国, 并使用了 Cloudflare CDN.
于是, 从 `geolocation-cn` 中删除.