### PR TITLE
update: xiaomitv-ads

### DIFF
--- a/data/xiaomitv-ads
+++ b/data/xiaomitv-ads
@@ -1,14 +1,12 @@
-pandora.mi.com @ads
 ad.mi.com @ads
 ad.xiaomi.com @ads
 ad1.xiaomi.com @ads
-data.mistat.xiaomi.com @ads
+mistat.xiaomi.com @ads
 tracking.miui.com @ads
 adv.sec.miui.com @ads
 misc.in.duokanbox.com @ads
 ad.hpplay.cn @ads
 adeng.hpplay.cn @ads
-auth.api.gitv.tv @ads
 atianqi.com @ads
 kuyun.com @ads
 umeng.com @ads


### PR DESCRIPTION
- 去除了不必要的规则
- 修复腾讯视频 iOS 版本投屏失败的问题

为了保证其它设备可以正常访问 `kuyun` `umeng` 等网站，建议为小米电视固定局域网 IP。此时可在配置文件中，仅针对小米电视屏蔽广告地址。

```JSON
{
  "type": "field",
  "outboundTag": "adblock",
  "source": ["192.168.10.114"],
  "domain": ["geosite:xiaomitv-ads"]
}
```