### PR TITLE
rearrange google and google-ads

### DIFF
--- a/data/google
+++ b/data/google
@@ -200,7 +200,6 @@ google
 goog
 
 # Others
-admob.com @ads
 adsense.com
 adwords.com
 abc.xyz
@@ -213,15 +212,9 @@ chrome.com
 chromebook.com
 cobrasearch.com
 feedburner.com
-doubleclick.com @ads
-doubleclick.net @ads
 igoogle.com
 foofle.com
 froogle.com
-googleanalytics.com @ads
-google-analytics.com @ads
-googletagmanager.com @ads
-googletagservices.com @ads
 googlecode.com
 googlesource.com
 googledrive.com
@@ -253,14 +246,12 @@ googil.com
 googlr.com
 googl.com
 gmodules.com
-googleadservices.com @ads
 googleapps.com
 googleapis.com
 googleapis.cn
 goo.gl
 googlebot.com
 googlecommerce.com
-googlesyndication.com @ads
 g.co
 whatbrowser.org
 withgoogle.com

--- a/data/google
+++ b/data/google
@@ -282,3 +282,4 @@ webmproject.org
 webrtc.org
 
 include:youtube
+include:google-ads

--- a/data/google
+++ b/data/google
@@ -200,8 +200,6 @@ google
 goog
 
 # Others
-adsense.com
-adwords.com
 abc.xyz
 android.com
 appspot.com

--- a/data/google-ads
+++ b/data/google-ads
@@ -1,3 +1,10 @@
-doubleclick.net @ads
-googlesyndication.com @ads
 admob.com @ads
+admob.com @ads
+doubleclick.com @ads
+doubleclick.net @ads
+googleanalytics.com @ads
+google-analytics.com @ads
+googletagmanager.com @ads
+googletagservices.com @ads
+googleadservices.com @ads
+googlesyndication.com @ads

--- a/data/google-ads
+++ b/data/google-ads
@@ -1,10 +1,11 @@
-admob.com @ads
-admob.com @ads
-doubleclick.com @ads
-doubleclick.net @ads
-googleanalytics.com @ads
-google-analytics.com @ads
-googletagmanager.com @ads
-googletagservices.com @ads
-googleadservices.com @ads
-googlesyndication.com @ads
+admob.com
+doubleclick.com
+doubleclick.net
+googleanalytics.com
+google-analytics.com
+googletagmanager.com
+googletagservices.com
+googleadservices.com
+googlesyndication.com
+adsense.com
+adwords.com


### PR DESCRIPTION
Some google-ads domains are mixed in google, causing them not being included by category-ads.
I moved ad domains to google-ads. I also removed @ads arribute from those ad domains, because if all domains in a file has the same arribute, the arribute is not even necessary, right?