### PR TITLE
Clear duplicate rules

### DIFF
--- a/data/category-ads
+++ b/data/category-ads
@@ -36,7 +36,6 @@ lqc006.com
 s4yxaqyq95.com
 shhs-ydd8x2.yjrmss.cn
 static.javhd.com
-toboads.com
 trafficfactory.biz
 
 # Ads serving for httpool.com

--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -95,13 +95,11 @@ moji.com
 900.la
 9718.com
 9xu.com
-abchina.com
 acfun.tv
 agrantsem.com
 aicdn.com
 aixifan.com
 allyes.com
-amap.com
 anjuke.com
 anquan.org
 appinn.com
@@ -184,7 +182,6 @@ ecitic.com
 edu.cn
 emarbox.com
 eoeandroid.com
-etao.com
 excelhome.net
 fanli.com
 feng.com
@@ -336,7 +333,6 @@ pps.tv
 psbc.com
 pubyun.com
 qbox.me
-qcloud.com
 qiaobutang.com
 qidian.com
 qie.tv
@@ -350,7 +346,6 @@ qiniudns.com
 qtmojo.com
 qunar.com
 qunarzz.com
-qzone.com
 renren.com
 rfchost.com
 runoob.com
@@ -414,7 +409,6 @@ weidian.com
 weiphone.com
 weiphone.net
 weixing.com
-weiyun.com
 wonnder.com
 worktile.com
 wooyun.org

--- a/data/google
+++ b/data/google
@@ -254,7 +254,6 @@ g.co
 whatbrowser.org
 withgoogle.com
 1e100.net
-ggpht.com
 googleusercontent.com
 googlecapital.com
 gv.com

--- a/data/microsoft
+++ b/data/microsoft
@@ -25,7 +25,6 @@ msedge.net
 office365.com
 live.net
 s-microsoft.com
-azureedge.net
 
 # Reference: SSL certificate subject alt name
 msecnd.net
@@ -49,7 +48,6 @@ powerappscdn.net
 tfsallin.net
 vsassets.io
 cortanaanalytics.com
-skype.com
 centralvalidation.com
 videobreakdown.com
 breakdown.me


### PR DESCRIPTION
`geolocation-cn` include `tencent` & `alibaba`, then:
```
    -amap.com
    -etao.com
    -qcloud.com
    -qzone.com
    -weiyun.com
```

`google` include `youtube`, then:
```
    -ggpht.com
```

other duplicate rules at same files:
```
    -toboads.com
    -abchina.com
    -azureedge.net
    -skype.com
```