### PR TITLE
Fix "Move jsDelivr back to `geolocation-cn`" #147

### DIFF
--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -33,7 +33,6 @@ include:hk01
 include:huanghuagang
 include:infrapedia
 include:jetbrains
-include:jsdelivr
 include:line
 include:linkedin
 include:microsoft

--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -14,6 +14,7 @@ include:huya
 include:iqiyi
 include:jd
 include:jiemian
+include:jsdelivr
 include:kuaishou
 include:mafengwo
 include:netease


### PR DESCRIPTION
Fix "Move jsDelivr back to `geolocation-cn`" #147

jsDelivr works perfectly inside China!

Sorry for my carelessness.