### PR TITLE
Refine & sort mozilla related sub-list

### DIFF
--- a/data/firefox
+++ b/data/firefox
@@ -1,2 +1,1 @@
 firefox.com
-firefox.com.cn

--- a/data/mdn
+++ b/data/mdn
@@ -1,0 +1,4 @@
+full:developer.mozilla.org
+full:interactive-examples.mdn.mozilla.net
+full:mdn.mozillademos.org
+full:media.prod.mdn.mozit.cloud

--- a/data/mozilla
+++ b/data/mozilla
@@ -1,11 +1,12 @@
-# Official site
+mozilla.net # short for domain download-installer.cdn.mozilla.net
 mozilla.org
 
-# Sub project
-thunderbird.net
+# Sub projects
 bugzilla.org
 getpocket.com
 seamonkey-project.org
-rust-lang.org
+thunderbird.net
 
 include:firefox
+include:mdn
+include:rust

--- a/data/rust
+++ b/data/rust
@@ -1,0 +1,2 @@
+rustup.rs
+rust-lang.org


### PR DESCRIPTION
`firefox.com.cn` is removed from firefox sub-list because it has access point in mainland China.