### PR TITLE
Include xdty & xingrz into geolocation-cn category

### DIFF
--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -114,6 +114,8 @@ include:startpage
 include:steemit
 include:tumblr
 include:wordpress
+include:xdty
+include:xingrz
 include:zeit
 
 # Communications

--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -42,9 +42,7 @@ include:tongcheng
 include:umeng
 include:unionpay
 include:wanfang
-include:xdty
 include:xiaomi
-include:xingrz
 include:ynet
 include:youku
 include:zhihu

--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -42,7 +42,9 @@ include:tongcheng
 include:umeng
 include:unionpay
 include:wanfang
+include:xdty
 include:xiaomi
+include:xingrz
 include:ynet
 include:youku
 include:zhihu

--- a/data/xdty
+++ b/data/xdty
@@ -1,0 +1,1 @@
+xdty.org

--- a/data/xingrz
+++ b/data/xingrz
@@ -1,0 +1,1 @@
+xingrz.me


### PR DESCRIPTION
xdty.org is a backend of [CallerInfo](https://github.com/xdtianyu/CallerInfo)
and xingrz.me is a backend of [Mantou Earth](https://github.com/oxoooo/earth)