### PR TITLE
Remove golang.org from google sub-list

### DIFF
--- a/data/google
+++ b/data/google
@@ -350,7 +350,6 @@ gmodules.com
 godoc.org
 gogle.com
 gogole.com
-golang.org
 gonglchuangl.net
 goo.gl
 googel.com


### PR DESCRIPTION
because domain `golang.org` already exists in `golang` sub-list