### PR TITLE
Fix: geosite:speedtest not found error

### DIFF
--- a/data/ookla-speedtest
+++ b/data/ookla-speedtest
@@ -1,0 +1,12 @@
+cdnst.net
+cellmaps.com
+ekahau.cloud
+ekahau.com
+ookla.com
+pingtest.net
+speedtest.co
+speedtest.net
+speedtestcustom.com
+webtest.net
+
+include:ookla-speedtest-ads

--- a/data/speedtest
+++ b/data/speedtest
@@ -1,0 +1,3 @@
+# This tag 'speedtest' is for backward compatibility of 'geosite:speedtest' in V2Ray.
+
+include:ookla-speedtest


### PR DESCRIPTION
Fix `geosite:speedtest` not found error for downstream third-party client & default configuration.

Domains extracted from the TLS certificate of `www.speedtest.net`