### PR TITLE
Update nintendo

### DIFF
--- a/data/nintendo
+++ b/data/nintendo
@@ -1,3 +1,17 @@
+nintendo-europe.com
+nintendo.at
+nintendo.be
+nintendo.ch
+nintendo.co.uk
+nintendo.co.za
 nintendo.com
 nintendo.com.hk
+nintendo.de
+nintendo.es
+nintendo.eu
+nintendo.fr
+nintendo.it
 nintendo.net
+nintendo.nl
+nintendo.pt
+nintendo.ru


### PR DESCRIPTION
domains are extracted from the TLS certificate of `www.nintendo.co.uk`