### PR TITLE
Include cern & nejm into category-scholar-!cn

### DIFF
--- a/data/category-scholar-!cn
+++ b/data/category-scholar-!cn
@@ -36,6 +36,7 @@ jneurosci.org
 jstor.org
 mdpi.com
 nature.com
+nejm.org
 neurology.org
 ovid.com
 peerj.com

--- a/data/category-scholar-!cn
+++ b/data/category-scholar-!cn
@@ -2,6 +2,7 @@
 
 include:apa
 include:cambridge
+include:cern
 include:clarivate
 include:doi
 include:elsevier

--- a/data/cern
+++ b/data/cern
@@ -1,0 +1,9 @@
+# All .cern domains
+cern
+
+ams02.space
+cern.ch
+cixp.net
+dotcernpilot.info
+ippog.org
+linearcollider.org


### PR DESCRIPTION
`cern` domains are extracted from TLS certificate of `home.cern`