### PR TITLE
Include tiktok & attwatchtv into geolocation-!cn category

### DIFF
--- a/data/attwatchtv
+++ b/data/attwatchtv
@@ -1,0 +1,6 @@
+att.tv
+atttvnow.com
+attwatchtv.com
+directv.com
+dtvce.com
+nettyinternet.com

--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -145,6 +145,7 @@ include:soundcloud
 include:spotify
 include:steam
 include:steamunlocked
+include:tiktok
 include:twitch
 include:ubi
 include:vimeo

--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -128,6 +128,7 @@ include:shopee
 
 # Entertainment & Videos & Games & Music
 include:archiveofourown
+include:attwatchtv
 include:bandcamp
 include:deviantart
 include:disney

--- a/data/tiktok
+++ b/data/tiktok
@@ -1,6 +1,7 @@
+muscdn.com
 musical.ly
+tiktok.com
 tiktokcdn.com
 tiktokv.com
-tiktok.com
 
 full:p16-tiktokcdn-com.akamaized.net


### PR DESCRIPTION
Domains in `attwatchtv` sub-list are extracted from TLS certificate of `www.attwatchtv.com`