### PR TITLE
Include voxmedia into category-media

### DIFF
--- a/data/category-media
+++ b/data/category-media
@@ -53,6 +53,7 @@ include:thestandnews
 include:udn
 include:unwire
 include:voanews
+include:voxmedia
 include:washingtonpost
 include:watchout
 include:wenzhao

--- a/data/voxmedia
+++ b/data/voxmedia
@@ -1,0 +1,16 @@
+cstatic.net
+curbed.com
+eater.com
+funnyordie.com
+meridian.net
+polygon.com
+racked.com
+recode.net
+sbnation.com
+theverge.com
+vox-cdn.com
+vox.com
+voxcreative.com
+voxfieldguide.com
+voxmedia.com
+voxops.net


### PR DESCRIPTION
Domains are extracted from TLS certificate of `voxmedia.com`