### PR TITLE
Add GitHub to geolocation-!cn

### DIFF
--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -30,6 +30,7 @@ include:amazon
 include:apple
 include:atlassian
 include:facebook
+include:github
 include:godaddy
 include:google
 include:hinet


### PR DESCRIPTION
My ISP returns `0.0.0.0` for DNS queries against `raw.githubusercontent.com`. I already set the rule `geosite:geolocation-!cn` to use `https://dns.google/dns-query` as the high priority DNS server. But since GitHub is not in `geolocation-!cn`, it fallbacks to use the DNS server provided by ISP.