### PR TITLE
Remove vali.cp31.ott.cibntv.net from youku-ads

### DIFF
--- a/data/youku-ads
+++ b/data/youku-ads
@@ -41,7 +41,6 @@ test.ott.youku.com @ads
 test.sdk.m.youku.com @ads
 v.l.youku.com @ads
 val.api.youku.com @ads
-vali.cp31.ott.cibntv.net @ads
 wan.youku.com @ads
 ykatr.youku.com @ads
 ykrec.youku.com @ads


### PR DESCRIPTION
Fixes #348 