### PR TITLE
Update playstation

### DIFF
--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -165,7 +165,6 @@ include:niconico
 include:nintendo
 include:overcast
 include:pixiv
-include:playstation
 include:pocketcasts
 include:sling
 include:sonypictures

--- a/data/geolocation-!cn
+++ b/data/geolocation-!cn
@@ -165,6 +165,7 @@ include:niconico
 include:nintendo
 include:overcast
 include:pixiv
+include:playstation
 include:pocketcasts
 include:sling
 include:sonypictures

--- a/data/playstation
+++ b/data/playstation
@@ -1,3 +1,6 @@
+# All .playstation domains
+playstation
+
 playstation.com
 playstation.net
 sonyentertainmentnetwork.com


### PR DESCRIPTION
Because sony alreadys includes the `playstation` and `geolocation-!cn` includes `sony`, I've removed `playstation` from `geolocation-!cn`.

If there are other opinions, please leave a comment.