### PR TITLE
Remove mzstatic.com

### DIFF
--- a/data/geolocation-cn
+++ b/data/geolocation-cn
@@ -842,7 +842,6 @@ mydrivers.com
 myshow360.net
 myyx618.com
 myzaker.com
-mzstatic.com
 naixuecha.com
 netbian.com
 newasp.net


### PR DESCRIPTION
mzstatic.com 域名为苹果所有，但不用于苹果中国业务，在中国各地查询该域名dns，IP均为美国地址